### PR TITLE
Improve store UX with direct installs

### DIFF
--- a/Feather/Backend/Observable/DownloadManager.swift
+++ b/Feather/Backend/Observable/DownloadManager.swift
@@ -125,20 +125,26 @@ class DownloadManager: NSObject, ObservableObject {
 
 extension DownloadManager: URLSessionDownloadDelegate {
 	
-	func handlePachageFile(url: URL, dl: Download) throws {
-		FR.handlePackageFile(url, download: dl) { err in
-			if err != nil {
-				let generator = UINotificationFeedbackGenerator()
-				generator.notificationOccurred(.error)
-			}
-			
-			DispatchQueue.main.async {
-				if let index = DownloadManager.shared.getDownloadIndex(by: dl.id) {
-					DownloadManager.shared.downloads.remove(at: index)
-				}
-			}
-		}
-	}
+        func handlePachageFile(url: URL, dl: Download) throws {
+                FR.handlePackageFile(url, uuid: dl.id, download: dl) { uuid, err in
+                        if err != nil {
+                                let generator = UINotificationFeedbackGenerator()
+                                generator.notificationOccurred(.error)
+                        }
+
+                        DispatchQueue.main.async {
+                                if let index = DownloadManager.shared.getDownloadIndex(by: dl.id) {
+                                        DownloadManager.shared.downloads.remove(at: index)
+                                }
+                                if let uuid {
+                                        NotificationCenter.default.post(
+                                                name: .downloadDidFinish,
+                                                object: uuid
+                                        )
+                                }
+                        }
+                }
+        }
 	
 	func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
 		guard let download = getDownloadTask(by: downloadTask) else { return }

--- a/Feather/Backend/Storage/Storage+Shared.swift
+++ b/Feather/Backend/Storage/Storage+Shared.swift
@@ -33,12 +33,18 @@ extension Storage {
 		}
 	}
 	
-	func getCertificate(from app: AppInfoPresentable) -> CertificatePair? {
-		if let signed = app as? Signed {
-			return signed.certificate
-		}
-		return nil
-	}
+        func getCertificate(from app: AppInfoPresentable) -> CertificatePair? {
+                if let signed = app as? Signed {
+                        return signed.certificate
+                }
+                return nil
+        }
+
+        func getImported(by uuid: String) -> Imported? {
+                let request: NSFetchRequest<Imported> = Imported.fetchRequest()
+                request.predicate = NSPredicate(format: "uuid == %@", uuid)
+                return (try? context.fetch(request))?.first
+        }
 }
 
 // MARK: - Helpers

--- a/Feather/Extensions/Notifications/Notification+Store.swift
+++ b/Feather/Extensions/Notifications/Notification+Store.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Notification.Name {
+    static let downloadDidFinish = Notification.Name("FeatherDownloadDidFinish")
+}

--- a/Feather/FeatherApp.swift
+++ b/Feather/FeatherApp.swift
@@ -38,15 +38,17 @@ struct FeatherApp: App {
 				}
 			}
 			// dear god help me
-			.onAppear {
-				if let style = UIUserInterfaceStyle(rawValue: UserDefaults.standard.integer(forKey: "Feather.userInterfaceStyle")) {
-					UIApplication.topViewController()?.view.window?.overrideUserInterfaceStyle = style
-				}
-				
-				UIApplication.topViewController()?.view.window?.tintColor = UIColor(Color(hex: UserDefaults.standard.string(forKey: "Feather.userTintColor") ?? "#B496DC"))
-			}
-		}
-	}
+                        .onAppear {
+                                if let style = UIUserInterfaceStyle(rawValue: UserDefaults.standard.integer(forKey: "Feather.userInterfaceStyle")) {
+                                        UIApplication.topViewController()?.view.window?.overrideUserInterfaceStyle = style
+                                }
+
+                                UIApplication.topViewController()?.view.window?.tintColor = UIColor(Color(hex: UserDefaults.standard.string(forKey: "Feather.userTintColor") ?? "#B496DC"))
+
+                                FR.ensureDefaultSource()
+                        }
+                }
+        }
 	
 	private func _handleURL(_ url: URL) {
 		if url.scheme == "feather" {
@@ -62,12 +64,12 @@ struct FeatherApp: App {
 			}
 		} else {
 			if url.pathExtension == "ipa" || url.pathExtension == "tipa" {
-				if FileManager.default.isFileFromFileProvider(at: url) {
-					guard url.startAccessingSecurityScopedResource() else { return }
-					FR.handlePackageFile(url) { _ in }
-				} else {
-					FR.handlePackageFile(url) { _ in }
-				}
+                                if FileManager.default.isFileFromFileProvider(at: url) {
+                                        guard url.startAccessingSecurityScopedResource() else { return }
+                                        FR.handlePackageFile(url) { _, _ in }
+                                } else {
+                                        FR.handlePackageFile(url) { _, _ in }
+                                }
 				
 				return
 			}

--- a/Feather/FeatherApp.swift
+++ b/Feather/FeatherApp.swift
@@ -20,15 +20,16 @@ struct FeatherApp: App {
 	
 	var body: some Scene {
 		WindowGroup {
-			VStack {
-				DownloadHeaderView(downloadManager: downloadManager)
-					.transition(.move(edge: .top).combined(with: .opacity))
-				VariedTabbarView()
-					.environment(\.managedObjectContext, storage.context)
-					.onOpenURL(perform: _handleURL)
-					.transition(.move(edge: .top).combined(with: .opacity))
-			}
-			.animation(.smooth, value: downloadManager.manualDownloads.description)
+                        VStack {
+                                DownloadHeaderView(downloadManager: downloadManager)
+                                        .transition(.move(edge: .top).combined(with: .opacity))
+                                VariedTabbarView()
+                                        .environment(\.managedObjectContext, storage.context)
+                                        .onOpenURL(perform: _handleURL)
+                                        .transition(.move(edge: .top).combined(with: .opacity))
+                        }
+                        .compatGlassBackground()
+                        .animation(.smooth, value: downloadManager.manualDownloads.description)
 			.onReceive(NotificationCenter.default.publisher(for: .heartbeatInvalidHost)) { _ in
 				DispatchQueue.main.async {
 					UIAlertController.showAlertWithOk(

--- a/Feather/Utilities/Handlers/AppFileHandler.swift
+++ b/Feather/Utilities/Handlers/AppFileHandler.swift
@@ -11,25 +11,28 @@ import SwiftUI
 import OSLog
 
 final class AppFileHandler: NSObject, @unchecked Sendable {
-	private let _fileManager = FileManager.default
-	private let _uuid = UUID().uuidString
+        private let _fileManager = FileManager.default
+        private let _uuid: String
 	private let _uniqueWorkDir: URL
-	var uniqueWorkDirPayload: URL?
+        var uniqueWorkDirPayload: URL?
+        var uuid: String { _uuid }
 
 	private var _ipa: URL
 	private let _install: Bool
 	private let _download: Download?
 	
-	init(
-		file ipa: URL,
-		install: Bool = false,
-		download: Download? = nil
-	) {
-		self._ipa = ipa
-		self._install = install
-		self._download = download
-		self._uniqueWorkDir = _fileManager.temporaryDirectory
-			.appendingPathComponent("FeatherImport_\(_uuid)", isDirectory: true)
+        init(
+                file ipa: URL,
+                install: Bool = false,
+                download: Download? = nil,
+                uuid: String? = nil
+        ) {
+                self._ipa = ipa
+                self._install = install
+                self._download = download
+                self._uuid = uuid ?? UUID().uuidString
+                self._uniqueWorkDir = _fileManager.temporaryDirectory
+                        .appendingPathComponent("FeatherImport_\(_uuid)", isDirectory: true)
 		
 		super.init()
 		Logger.misc.debug("Import initiated for: \(self._ipa.lastPathComponent) with ID: \(self._uuid)")

--- a/Feather/Views/Sources/Apps/SourceAppsCellView.swift
+++ b/Feather/Views/Sources/Apps/SourceAppsCellView.swift
@@ -18,8 +18,9 @@ struct SourceAppsCellView: View {
 	@AppStorage("Feather.storeCellAppearance") private var _storeCellAppearance: Int = 0
 	
 	@State private var _downloadProgress: Double = 0
-        @State var cancellable: AnyCancellable? // Combine
-        @State private var _presentInstall: Imported?
+    @State var cancellable: AnyCancellable? // Combine
+    @State private var _presentInstall: Imported?
+    @State private var _presentDetails = false
 	
 	var currentDownload: Download? {
 		downloadManager.getDownload(by: app.currentUniqueId)
@@ -27,32 +28,37 @@ struct SourceAppsCellView: View {
 	
 	var app: ASRepository.App
 	
-	var body: some View {
-		VStack {
-			HStack(spacing: 2) {
-				FRIconCellView(
-					title: app.currentName,
-					subtitle: _appDescription(app: app),
-					iconUrl: app.iconURL
-				)
-				_download()
-			}
-			
-			if _storeCellAppearance != 0 {
-				Text(app.localizedDescription ?? "")
-					.frame(maxWidth: .infinity, alignment: .leading)
-					.font(.subheadline)
-					.foregroundStyle(.secondary)
-					.lineLimit(18)
-					.padding(.top, 2)
-			}
-		}
-		.padding(.vertical, {
-			if #available(iOS 19, *) {
-				return 6
-			} else {
-				return 0
-			}
+        var body: some View {
+                Button {
+                        _presentDetails = true
+                } label: {
+                        VStack {
+                                HStack(spacing: 2) {
+                                        FRIconCellView(
+                                                title: app.currentName,
+                                                subtitle: _appDescription(app: app),
+                                                iconUrl: app.iconURL
+                                        )
+                                        _download()
+                                }
+
+                                if _storeCellAppearance != 0 {
+                                        Text(app.localizedDescription ?? "")
+                                                .frame(maxWidth: .infinity, alignment: .leading)
+                                                .font(.subheadline)
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(18)
+                                                .padding(.top, 2)
+                                }
+                        }
+                }
+                .buttonStyle(.plain)
+                .padding(.vertical, {
+                        if #available(iOS 19, *) {
+                                return 6
+                        } else {
+                                return 0
+                        }
 		}())
                 .onAppear(perform: _setupDownloadObserver)
                 .onDisappear {
@@ -72,7 +78,10 @@ struct SourceAppsCellView: View {
                         InstallPreviewView(app: item)
                                 .presentationDetents([.height(200)])
                 }
-	}
+                .sheet(isPresented: $_presentDetails) {
+                        StoreAppInfoView(app: app)
+                }
+        }
 	
 	private func _setupDownloadObserver() {
 		cancellable?.cancel()

--- a/Feather/Views/Sources/Apps/StoreAppInfoView.swift
+++ b/Feather/Views/Sources/Apps/StoreAppInfoView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import AltSourceKit
+import NimbleViews
+import NukeUI
+
+struct StoreAppInfoView: View {
+    @Environment(\.dismiss) private var dismiss
+    var app: ASRepository.App
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack(alignment: .top, spacing: 16) {
+                        if let iconURL = app.iconURL {
+                            LazyImage(url: iconURL) { state in
+                                if let image = state.image {
+                                    image.resizable()
+                                }
+                            }
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(app.currentName)
+                                .font(.title.bold())
+                            if let subtitle = app.subtitle ?? app.localizedDescription {
+                                Text(subtitle)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        if let url = app.currentDownloadUrl {
+                            Button {
+                                _ = DownloadManager.shared.startDownload(from: url, id: app.currentUniqueId)
+                                dismiss()
+                            } label: {
+                                NBButton("Get", style: .text)
+                            }
+                        }
+                    }
+
+                    if let description = app.description ?? app.localizedDescription {
+                        Text(description)
+                            .font(.body)
+                    }
+
+                    if let screenshots = app.screenshotURLs, !screenshots.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            LazyHStack(spacing: 12) {
+                                ForEach(screenshots, id: \.self) { url in
+                                    LazyImage(url: url) { state in
+                                        if let image = state.image {
+                                            image
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                        }
+                                    }
+                                    .frame(width: 240, height: 480)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                }
+                            }
+                            .padding(.horizontal)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle(app.currentName)
+            .toolbar { NBToolbarButton(role: .close) }
+        }
+    }
+}

--- a/Feather/Views/Sources/SourcesView.swift
+++ b/Feather/Views/Sources/SourcesView.swift
@@ -16,8 +16,7 @@ struct StoreView: View {
 	
 	@AppStorage("Feather.shouldStar") private var _shouldStar: Int = 0
 	
-	@StateObject var viewModel = SourcesViewModel.shared
-        @State private var _searchText = ""
+        @StateObject var viewModel = SourcesViewModel.shared
 	
         @FetchRequest(
                 entity: AltSource.entity(),
@@ -28,8 +27,9 @@ struct StoreView: View {
 	// MARK: Body
         var body: some View {
                 NBNavigationView(.localized("Store")) {
-                        if let source = _sources.first {
-                                SourceAppsView(object: [source], viewModel: viewModel)
+                        if let source = _sources.first,
+                           let repo = viewModel.sources[source] {
+                                StoreHomeView(repository: repo)
                         } else {
                                 ProgressView()
                         }

--- a/Feather/Views/Store/StoreAppCardView.swift
+++ b/Feather/Views/Store/StoreAppCardView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import AltSourceKit
+import NimbleViews
+import NukeUI
+
+struct StoreAppCardView: View {
+    var app: ASRepository.App
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let screenshot = app.screenshotURLs?.first {
+                LazyImage(url: screenshot) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    }
+                }
+                .frame(height: 220)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+
+            HStack(alignment: .top, spacing: 12) {
+                if let iconURL = app.iconURL {
+                    LazyImage(url: iconURL) { state in
+                        if let image = state.image {
+                            image.appIconStyle(size: 60)
+                        }
+                    }
+                } else {
+                    Image("App_Unknown")
+                        .appIconStyle(size: 60)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(app.currentName)
+                        .font(.headline)
+                    if let subtitle = app.subtitle ?? app.localizedDescription {
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+                Spacer()
+                if let url = app.currentDownloadUrl {
+                    Button {
+                        _ = DownloadManager.shared.startDownload(from: url, id: app.currentUniqueId)
+                    } label: {
+                        NBButton("Get", style: .text)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}

--- a/Feather/Views/Store/StoreHomeView.swift
+++ b/Feather/Views/Store/StoreHomeView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import AltSourceKit
+import CoreData
+import NimbleViews
+
+struct StoreHomeView: View {
+    @StateObject var viewModel = SourcesViewModel.shared
+    @State private var _selectedApp: ASRepository.App?
+
+    var repository: ASRepository
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                if let news = repository.news, !news.isEmpty {
+                    SourceNewsView(news: news)
+                }
+
+                NBGrid {
+                    ForEach(repository.apps, id: \.id) { app in
+                        Button {
+                            _selectedApp = app
+                        } label: {
+                            StoreAppCardView(app: app)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .sheet(item: $_selectedApp) { app in
+            StoreAppInfoView(app: app)
+        }
+    }
+}

--- a/Feather/Views/TabView/Bars/ExtendedTabbarView.swift
+++ b/Feather/Views/TabView/Bars/ExtendedTabbarView.swift
@@ -13,15 +13,7 @@ import NukeUI
 struct ExtendedTabbarView: View {
 	@Environment(\.horizontalSizeClass) var horizontalSizeClass
 	@AppStorage("Feather.tabCustomization") var customization = TabViewCustomization()
-	@StateObject var viewModel = SourcesViewModel.shared
-	
-	@State private var _isAddingPresenting = false
-	
-	@FetchRequest(
-		entity: AltSource.entity(),
-		sortDescriptors: [NSSortDescriptor(keyPath: \AltSource.name, ascending: true)],
-		animation: .snappy
-	) private var _sources: FetchedResults<AltSource>
+        @StateObject var viewModel = SourcesViewModel.shared
 		
 	var body: some View {
 		TabView {
@@ -31,53 +23,20 @@ struct ExtendedTabbarView: View {
 				}
 			}
 			
-			ForEach(TabEnum.customizableTabs, id: \.hashValue) { tab in
-				Tab(tab.title, systemImage: tab.icon) {
-					TabEnum.view(for: tab)
-				}
-				.customizationID("tab.\(tab.rawValue)")
-				.defaultVisibility(.hidden, for: .tabBar)
-				.customizationBehavior(.reorderable, for: .tabBar, .sidebar)
-				.hidden(horizontalSizeClass == .compact)
-			}
-			
-			TabSection("Sources") {
-				Tab(.localized("All Repositories"), systemImage: "globe.desk") {
-					NavigationStack {
-						SourceAppsView(object: Array(_sources), viewModel: viewModel)
-					}
-				}
-				
-				ForEach(_sources, id: \.identifier) { source in
-					Tab {
-						NavigationStack {
-							SourceAppsView(object: [source], viewModel: viewModel)
-						}
-					} label: {
-						_icon(source.name ?? .localized("Unknown"), iconUrl: source.iconURL)
-					}
-					.swipeActions {
-						Button(.localized("Delete"), systemImage: "trash", role: .destructive) {
-							Storage.shared.deleteSource(for: source)
-						}
-					}
-				}
-			}
-			.sectionActions {
-				Button(.localized("Add Source"), systemImage: "plus") {
-					_isAddingPresenting = true
-				}
-			}
-			.defaultVisibility(.hidden, for: .tabBar)
-			.hidden(horizontalSizeClass == .compact)
-		}
-		.tabViewStyle(.sidebarAdaptable)
-		.tabViewCustomization($customization)
-		.sheet(isPresented: $_isAddingPresenting) {
-			SourcesAddView()
-				.presentationDetents([.medium])
-		}
-	}
+                        ForEach(TabEnum.customizableTabs, id: \.hashValue) { tab in
+                                Tab(tab.title, systemImage: tab.icon) {
+                                        TabEnum.view(for: tab)
+                                }
+                                .customizationID("tab.\(tab.rawValue)")
+                                .defaultVisibility(.hidden, for: .tabBar)
+                                .customizationBehavior(.reorderable, for: .tabBar, .sidebar)
+                                .hidden(horizontalSizeClass == .compact)
+                        }
+                }
+                .tabViewStyle(.sidebarAdaptable)
+                .tabViewCustomization($customization)
+                
+        }
 	
 	@ViewBuilder
 	private func _icon(_ title: String, iconUrl: URL?) -> some View {

--- a/Feather/Views/TabView/Bars/TabbarView.swift
+++ b/Feather/Views/TabView/Bars/TabbarView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TabbarView: View {
-	@State private var selectedTab: TabEnum = .sources
+	@State private var selectedTab: TabEnum = .store
 
 	var body: some View {
 		TabView(selection: $selectedTab) {

--- a/Feather/Views/TabView/TabEnum.swift
+++ b/Feather/Views/TabView/TabEnum.swift
@@ -9,14 +9,14 @@ import SwiftUI
 import NimbleViews
 
 enum TabEnum: String, CaseIterable, Hashable {
-	case sources
-	case library
-	case settings
-	case certificates
+        case store
+        case library
+        case settings
+        case certificates
 	
 	var title: String {
 		switch self {
-		case .sources:     	return .localized("Sources")
+		case .store:     	return .localized("Store")
 		case .library: 		return .localized("Library")
 		case .settings: 	return .localized("Settings")
 		case .certificates:	return .localized("Certificates")
@@ -25,7 +25,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 	
 	var icon: String {
 		switch self {
-		case .sources: 		return "globe.desk"
+		case .store: 		return "cart"
 		case .library: 		return "square.grid.2x2"
 		case .settings: 	return "gearshape.2"
 		case .certificates: return "person.text.rectangle"
@@ -35,7 +35,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 	@ViewBuilder
 	static func view(for tab: TabEnum) -> some View {
 		switch tab {
-		case .sources: SourcesView()
+		case .store: StoreView()
 		case .library: LibraryView()
 		case .settings: SettingsView()
 		case .certificates: NBNavigationView(.localized("Certificates")) { CertificatesView() }
@@ -44,7 +44,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 	
 	static var defaultTabs: [TabEnum] {
 		return [
-			.sources,
+			.store,
 			.library,
 			.settings
 		]

--- a/NimbleKit/Sources/NimbleExtensions/View/View+compatGlass.swift
+++ b/NimbleKit/Sources/NimbleExtensions/View/View+compatGlass.swift
@@ -1,0 +1,21 @@
+//
+//  View+compatGlass.swift
+//  NimbleKit
+//
+//  Created by Codex on 2025.
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies the glass background effect when available.
+    @ViewBuilder
+    public func compatGlassBackground() -> some View {
+        if #available(iOS 19.0, *) {
+            self.glassBackgroundEffect()
+        } else {
+            self
+        }
+    }
+}
+

--- a/NimbleKit/Sources/NimbleExtensions/View/View+compatGlass.swift
+++ b/NimbleKit/Sources/NimbleExtensions/View/View+compatGlass.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 extension View {
-    /// Applies the glass background effect when available.
+    /// Applies a translucent background similar to visionOS.
     @ViewBuilder
     public func compatGlassBackground() -> some View {
-        if #available(iOS 19.0, *) {
-            self.glassBackgroundEffect()
+        if #available(iOS 15.0, *) {
+            self.background(.ultraThinMaterial)
         } else {
             self
         }

--- a/NimbleKit/Sources/NimbleViews/Views/NBButton.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBButton.swift
@@ -31,16 +31,18 @@ public struct NBButton: View {
 			Image(systemName: _icon)
 				.font(.caption).bold()
 				.frame(width: 29, height: 29)
-				.background(Color(uiColor: .quaternarySystemFill))
-				.clipShape(Circle())
+                                .background(.ultraThinMaterial)
+                                .compatGlassBackground()
+                                .clipShape(Circle())
 			
 		case .text:
 			Text(_title)
 				.font(.footnote).bold()
 				.padding(.horizontal, _horizontalPadding)
 				.frame(height: 29)
-				.background(Color(uiColor: .quaternarySystemFill))
-				.clipShape(Capsule())
+                                .background(.ultraThinMaterial)
+                                .compatGlassBackground()
+                                .clipShape(Capsule())
 		}
     }
 }

--- a/NimbleKit/Sources/NimbleViews/Views/NBGrid.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBGrid.swift
@@ -18,11 +18,13 @@ public struct NBGrid<Content>: View where Content: View {
 		self._content = content()
 	}
 	
-	public var body: some View {
-		ScrollView {
-			LazyVGrid(columns: _adaptiveColumns, spacing: 16) {
-				_content
-			}.padding(.horizontal)
-		}
-	}
+        public var body: some View {
+                ScrollView {
+                        LazyVGrid(columns: _adaptiveColumns, spacing: 16) {
+                                _content
+                        }
+                        .padding(.horizontal)
+                }
+                .compatGlassBackground()
+        }
 }

--- a/NimbleKit/Sources/NimbleViews/Views/NBList.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBList.swift
@@ -30,20 +30,21 @@ public struct NBList<Content>: View where Content: View {
 		self._content = content()
 	}
 	
-	public var body: some View {
-		Group {
-			switch _type {
-			case .form:
-				Form {
-					_content
-				}
-			case .list:
-				List {
-					_content
-				}
-			}
-		}
-		.navigationTitle(_title)
-		.navigationBarTitleDisplayMode(_mode)
-	}
+        public var body: some View {
+                Group {
+                        switch _type {
+                        case .form:
+                                Form {
+                                        _content
+                                }
+                        case .list:
+                                List {
+                                        _content
+                                }
+                        }
+                }
+                .navigationTitle(_title)
+                .navigationBarTitleDisplayMode(_mode)
+                .compatGlassBackground()
+        }
 }

--- a/NimbleKit/Sources/NimbleViews/Views/NBListAdaptable.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBListAdaptable.swift
@@ -16,16 +16,18 @@ public struct NBListAdaptable<Content>: View where Content: View {
 		self._content = content()
 	}
 	
-	public var body: some View {
-		if horizontalSizeClass == .compact {
-			List {
-				_content
-			}
-			.listStyle(.plain)
-		} else {
-			NBGrid {
-				_content
-			}
-		}
-	}
+        public var body: some View {
+                if horizontalSizeClass == .compact {
+                        List {
+                                _content
+                        }
+                        .listStyle(.plain)
+                        .compatGlassBackground()
+                } else {
+                        NBGrid {
+                                _content
+                        }
+                        .compatGlassBackground()
+                }
+        }
 }

--- a/NimbleKit/Sources/NimbleViews/Views/NBNavigationView.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBNavigationView.swift
@@ -22,11 +22,12 @@ public struct NBNavigationView<Content>: View where Content: View {
 		self._content = content()
 	}
 	
-	public var body: some View {
-		NavigationStack {
-			_content
-				.navigationTitle(_title)
-				.navigationBarTitleDisplayMode(_mode)
-		}
-	}
+        public var body: some View {
+                NavigationStack {
+                        _content
+                                .navigationTitle(_title)
+                                .navigationBarTitleDisplayMode(_mode)
+                }
+                .compatGlassBackground()
+        }
 }

--- a/NimbleKit/Sources/NimbleViews/Views/NBSection.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBSection.swift
@@ -67,8 +67,9 @@ where 	Content: View,
 							.contentTransition(.numericText())
                             .padding(.horizontal, 8)
 							.padding(.vertical, 4.4)
-							.background(Color(uiColor: .quaternarySystemFill))
-							.clipShape(Capsule())
+                                                        .background(.ultraThinMaterial)
+                                                        .compatGlassBackground()
+                                                        .clipShape(Capsule())
 					}
 				}
 				.offset(y: 2)

--- a/NimbleKit/Sources/NimbleViews/Views/NBSheetButton.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBSheetButton.swift
@@ -19,7 +19,7 @@ public struct NBSheetButton: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(.ultraThinMaterial)
                         .compatGlassBackground()
-                        .foregroundStyle(.accent)
+                        .foregroundStyle(Color.accentColor)
                         .clipShape(
                                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                         )

--- a/NimbleKit/Sources/NimbleViews/Views/NBSheetButton.swift
+++ b/NimbleKit/Sources/NimbleViews/Views/NBSheetButton.swift
@@ -15,14 +15,15 @@ public struct NBSheetButton: View {
 	}
 	
 	public var body: some View {
-		Text(_title)
-			.frame(maxWidth: .infinity, maxHeight: .infinity)
-			.background(Color.accentColor)
-			.foregroundColor(.white)
-			.clipShape(
-				RoundedRectangle(cornerRadius: 12, style: .continuous)
-			)
-			.bold()
+                Text(_title)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(.ultraThinMaterial)
+                        .compatGlassBackground()
+                        .foregroundStyle(.accent)
+                        .clipShape(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        )
+                        .bold()
 			.frame(height: 50)
 			.padding()
 	}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The interface now embraces Apple's Liquid Glass look inspired by visionOS, with 
 
 ### Features
 - Install applications via [`idevice`](https://github.com/jkcoxson/idevice) or using a [`server`](https://github.com/vapor/vapor).
-- Browse and install apps directly from the official Feather store.
+- Browse a single unified store with detailed app pages and one-tap installs.
 - Globally configurable signing options, and even supports Adhoc signing.
 - Advanced tweak support, using [Ellekit](https://github.com/tealbathingsuit/ellekit) for injection. Supports `.deb` and `.dylib` files.
 - No tracking or analytics, ensuring user privacy.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ All applications are provided through a single official repository bundled with 
 
 The interface now embraces Apple's Liquid Glass look inspired by visionOS, with translucent backgrounds across the app.
 
+A redesigned Store showcases apps with large cards just like the Apple App Store.
+
 <p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="Images/Image-dark.png"><source media="(prefers-color-scheme: light)" srcset="Images/Image-light.png"><img alt="Pointercrate-pocket." src="Images/Image-light.png"></picture></p>
 
 ### Features
 - Install applications via [`idevice`](https://github.com/jkcoxson/idevice) or using a [`server`](https://github.com/vapor/vapor).
-- Browse a single unified store with detailed app pages and one-tap installs.
+- Browse a single unified store with App Store–style cards, detailed app pages and one-tap installs.
 - Globally configurable signing options, and even supports Adhoc signing.
 - Advanced tweak support, using [Ellekit](https://github.com/tealbathingsuit/ellekit) for injection. Supports `.deb` and `.dylib` files.
 - No tracking or analytics, ensuring user privacy.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is an entirely stock application and uses built-in features to be able to d
 
 All applications are provided through a single official repository bundled with the app.
 
+The interface now embraces Apple's Liquid Glass look inspired by visionOS, with translucent backgrounds across the app.
+
 <p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="Images/Image-dark.png"><source media="(prefers-color-scheme: light)" srcset="Images/Image-light.png"><img alt="Pointercrate-pocket." src="Images/Image-light.png"></picture></p>
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 [![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/khcrysalis/feather/total)](https://github.com/khcrysalis/feather/releases)
 [![GitHub License](https://img.shields.io/github/license/khcrysalis/feather?color=%23C96FAD)](https://github.com/khcrysalis/feather/blob/main/LICENSE)
 
-This app allows you to install and manage applications contained in a single app, using certificate pairs and various installation techniques to allow apps to install to your device. 
+This app allows you to install and manage applications contained in a single app, using certificate pairs and various installation techniques to allow apps to install to your device.
 
 This is an entirely stock application and uses built-in features to be able to do this!
+
+All applications are provided through a single official repository bundled with the app.
 
 <p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="Images/Image-dark.png"><source media="(prefers-color-scheme: light)" srcset="Images/Image-light.png"><img alt="Pointercrate-pocket." src="Images/Image-light.png"></picture></p>
 
 ### Features
 - Install applications via [`idevice`](https://github.com/jkcoxson/idevice) or using a [`server`](https://github.com/vapor/vapor).
-- Inspect and manage imported apps, certificates, and altstore sources.
+- Browse and install apps directly from the official Feather store.
 - Globally configurable signing options, and even supports Adhoc signing.
 - Advanced tweak support, using [Ellekit](https://github.com/tealbathingsuit/ellekit) for injection. Supports `.deb` and `.dylib` files.
 - No tracking or analytics, ensuring user privacy.


### PR DESCRIPTION
## Summary
- trigger install sheet when a store download finishes
- identify downloads using their own UUID
- broadcast a notification on completed downloads
- add helper to fetch imported apps by UUID
- document installing directly from the store in README

## Testing
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68561b8bdd1c832d8e0e47051307a8aa